### PR TITLE
Allow cloning the hash ring to use iterators effectively

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,6 +88,7 @@ use std::fmt::Debug;
 use std::hash::BuildHasher;
 use std::hash::{Hash, Hasher};
 
+#[derive(Clone)]
 pub struct DefaultHashBuilder;
 
 impl BuildHasher for DefaultHashBuilder {
@@ -133,6 +134,7 @@ impl<T> Ord for Node<T> {
     }
 }
 
+#[derive(Clone)]
 pub struct HashRing<T, S = DefaultHashBuilder> {
     hash_builder: S,
     ring: Vec<Node<T>>,
@@ -481,5 +483,32 @@ mod tests {
         assert_eq!(Some(vnode3), iter.next());
         assert_eq!(Some(vnode2), iter.next());
         assert_eq!(None, iter.next());
+    }
+
+    struct TestIterStruct {
+        ring: HashRing<String>,
+    }
+
+    impl TestIterStruct {
+        pub fn print_each(&self) -> Vec<String> {
+            let mut v = Vec::new();
+            for node in self.ring.clone().into_iter() {
+                v.push(node);
+            }
+            v
+        }
+    }
+
+    #[test]
+    fn into_iter_for_struct_field() {
+        let mut ring: HashRing<String> = HashRing::new();
+        ring.add("foo".to_string());
+        ring.add("bar".to_string());
+
+        let s = TestIterStruct { ring };
+
+        let v = s.print_each();
+
+        assert_eq!(v.len(), 2);
     }
 }


### PR DESCRIPTION
There was a case (that is outlined in the test) that did not work, due to not being able to clone.

The iterator worked fine for the cases where the HashRing is in a single context, but as soon as it is shared we cannot iterate through the entire list.

If you know a better way to get around this, please let me know, but this was the only solution that I could find.