### PR TITLE
add a batch_add feature to avoid sort for each virtual node addition

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -185,11 +185,11 @@ impl<T: Hash, S: BuildHasher> HashRing<T, S> {
         self.ring.sort();
     }
 
-    pub fn batch_add(&mut self, nodes:Vec<T> ) {
-       for node in nodes {
-           let key = get_key(&self.hash_builder, &node);
-           self.ring.push(Node::new(key, node));
-       }
+    pub fn batch_add(&mut self, nodes: Vec<T>) {
+        for node in nodes {
+            let key = get_key(&self.hash_builder, &node);
+            self.ring.push(Node::new(key, node));
+        }
         self.ring.sort()
     }
 
@@ -340,9 +340,7 @@ mod tests {
         let vnode5 = VNode::new("127.0.0.2", 1024, 3);
         let vnode6 = VNode::new("127.0.0.3", 1024, 1);
 
-        ring.add(vnode4);
-        ring.add(vnode5);
-        ring.add(vnode6);
+        ring.batch_add(vec![vnode4, vnode5, vnode6]);
 
         assert_eq!(ring.remove(&vnode1).unwrap(), vnode1);
         assert_eq!(ring.remove(&vnode3).unwrap(), vnode3);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -185,6 +185,14 @@ impl<T: Hash, S: BuildHasher> HashRing<T, S> {
         self.ring.sort();
     }
 
+    pub fn batch_add(&mut self, nodes:Vec<T> ) {
+       for node in nodes {
+           let key = get_key(&self.hash_builder, &node);
+           self.ring.push(Node::new(key, node));
+       }
+        self.ring.sort()
+    }
+
     /// Remove `node` from the hash ring. Returns an `Option` that will contain the `node`
     /// if it was in the hash ring or `None` if it was not present.
     pub fn remove(&mut self, node: &T) -> Option<T> {


### PR DESCRIPTION
in some of our setups we need to increase virtual nodes to 10k to get a better distribution of the data. This is to add a batch API to speedup the building process