### PR TITLE
Derive Clone on HashRing type

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -496,31 +496,4 @@ mod tests {
         assert_eq!(Some(vnode2), iter.next());
         assert_eq!(None, iter.next());
     }
-
-    struct TestIterStruct {
-        ring: HashRing<String>,
-    }
-
-    impl TestIterStruct {
-        pub fn print_each(&self) -> Vec<String> {
-            let mut v = Vec::new();
-            for node in self.ring.clone().into_iter() {
-                v.push(node);
-            }
-            v
-        }
-    }
-
-    #[test]
-    fn into_iter_for_struct_field() {
-        let mut ring: HashRing<String> = HashRing::new();
-        ring.add("foo".to_string());
-        ring.add("bar".to_string());
-
-        let s = TestIterStruct { ring };
-
-        let v = s.print_each();
-
-        assert_eq!(v.len(), 2);
-    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,6 +88,7 @@ use std::fmt::Debug;
 use std::hash::BuildHasher;
 use std::hash::Hash;
 
+#[derive(Clone)]
 pub struct DefaultHashBuilder;
 
 impl BuildHasher for DefaultHashBuilder {
@@ -133,6 +134,7 @@ impl<T> Ord for Node<T> {
     }
 }
 
+#[derive(Clone)]
 pub struct HashRing<T, S = DefaultHashBuilder> {
     hash_builder: S,
     ring: Vec<Node<T>>,
@@ -493,5 +495,32 @@ mod tests {
         assert_eq!(Some(vnode1), iter.next());
         assert_eq!(Some(vnode2), iter.next());
         assert_eq!(None, iter.next());
+    }
+
+    struct TestIterStruct {
+        ring: HashRing<String>,
+    }
+
+    impl TestIterStruct {
+        pub fn print_each(&self) -> Vec<String> {
+            let mut v = Vec::new();
+            for node in self.ring.clone().into_iter() {
+                v.push(node);
+            }
+            v
+        }
+    }
+
+    #[test]
+    fn into_iter_for_struct_field() {
+        let mut ring: HashRing<String> = HashRing::new();
+        ring.add("foo".to_string());
+        ring.add("bar".to_string());
+
+        let s = TestIterStruct { ring };
+
+        let v = s.print_each();
+
+        assert_eq!(v.len(), 2);
     }
 }


### PR DESCRIPTION
Continuation of <https://github.com/jeromefroe/hashring-rs/pull/20>.

This derives `Clone` on the `HashRing` type.

As explained [here](https://github.com/jeromefroe/hashring-rs/pull/20#issuecomment-2115052741), we'd like to have this at Qdrant for dynamic resharding where we clone and update a pair of hashrings.

This is a continuation of the above mentioned PR. I removed the test though, because it doesn't add any value to the cloning itself. I'm assuming the author needs an [`iter()`](https://doc.rust-lang.org/std/vec/struct.Vec.html#method.iter) which would not need cloning at all. But that would be something for a separate PR.