### PR TITLE
Remove `T: Clone` bound from `IntoIterator` implementation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -274,7 +274,7 @@ impl<T> Iterator for HashRingIterator<T> {
     }
 }
 
-impl<T: Clone> IntoIterator for HashRing<T> {
+impl<T> IntoIterator for HashRing<T> {
     type Item = T;
 
     type IntoIter = HashRingIterator<T>;


### PR DESCRIPTION
There is a `T: Clone` trait bound in the `IntoIterator` implementation for `HashRing<T>`, which is not necessary and forbids calling `into_iter` on a `HashRing<NonClone>`, even though it's perfectly valid.

This should not be a breaking change, cause we only "remove" requirements on `T`.