### PR TITLE
feat: with replicas unique by key + some fixes & performance improvements

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -562,9 +562,9 @@ mod tests {
         );
 
         assert_eq!(
-            ring.get_with_replicas_unique_by_key(&"bar", 4, |vnode| vnode.addr).unwrap().len(),
-            3,
-            "replica < count_of_unique_elements causes the count to match replica + 1 (primary)"
+            ring.get_with_replicas_unique_by_key(&"bar", 1, |vnode| vnode.addr).unwrap().len(),
+            2,
+            "replicas < count_of_unique_elements causes the count to match replicas + 1 (including primary)"
         );
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -295,9 +295,9 @@ impl<T: Hash, S: BuildHasher> HashRing<T, S> {
             let idx = (n + i) % len;
             let node = &self.ring[idx];
 
-            let key = unique_key(&node.node);
+            let unique = unique_key(&node.node);
 
-            if seen.insert(key) {
+            if seen.insert(unique) {
                 replica_nodes.push(node.node.clone());
 
                 if replica_nodes.len() == replicas {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -245,9 +245,6 @@ impl<T: Hash, S: BuildHasher> HashRing<T, S> {
             Ok(n) => n,
         };
 
-        let mut nodes = self.ring.clone();
-        nodes.rotate_left(n);
-
         let mut replica_nodes = Vec::with_capacity(replicas);
         let len = self.ring.len();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -265,10 +265,14 @@ impl<T: Hash, S: BuildHasher> HashRing<T, S> {
         Some(replica_nodes)
     }
 
-    /// Get the node responsible for `key` along with the next `replica` unique nodes after.
-    /// Returns None when the ring is empty. If `replicas` is larger than the length
-    /// of the ring, this function will shrink to just contain each unique element of the ring.
-    /// The `Eq` implementation of `T` is used as the uniqueness criteria.
+    /// Get the node responsible for `key` (the primary) along with up to `replicas`
+    /// additional unique nodes after it, where uniqueness is determined by the
+    /// values produced by the `unique_key` closure.
+    /// Returns `None` when the ring is empty. If `replicas` is larger than the length
+    /// of the ring, this function will shrink to just contain each unique element of
+    /// the ring, up to `replicas + 1` nodes (primary plus replicas). If there are fewer
+    /// distinct `unique_key` values than requested, the returned vector will contain
+    /// fewer than `replicas + 1` nodes.
     pub fn get_with_replicas_unique_by_key<U: Hash, F, K>(&self, key: &U, replicas: usize, unique_key: F) -> Option<Vec<T>>
     where
         T: Clone + Debug,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,6 +84,7 @@ extern crate siphasher;
 
 use siphasher::sip::SipHasher;
 use std::cmp::Ordering;
+use std::collections::HashSet;
 use std::fmt::Debug;
 use std::hash::BuildHasher;
 use std::hash::Hash;
@@ -251,12 +252,61 @@ impl<T: Hash, S: BuildHasher> HashRing<T, S> {
         let mut nodes = self.ring.clone();
         nodes.rotate_left(n);
 
+        // DANGER / TODO: could hang indefinitely
         let replica_nodes = nodes
             .iter()
             .cycle()
             .take(replicas)
             .map(|node| node.node.clone())
             .collect();
+
+        Some(replica_nodes)
+    }
+
+    /// Get the node responsible for `key` along with the next `replica` unique nodes after.
+    /// Returns None when the ring is empty. If `replicas` is larger than the length
+    /// of the ring, this function will shrink to just contain each unique element of the ring.
+    /// The `Eq` implementation of `T` is used as the uniqueness criteria.
+    pub fn get_with_replicas_unique_by_key<U: Hash, F, K>(&self, key: &U, replicas: usize, unique_key: F) -> Option<Vec<T>>
+    where
+        T: Clone + Debug,
+        F: Fn(&T) -> K,
+        K: Hash + Eq,
+    {
+        if self.ring.is_empty() {
+            return None;
+        }
+
+        let replicas = if replicas > self.ring.len() {
+            self.ring.len()
+        } else {
+            replicas + 1
+        };
+
+        let k = get_key(&self.hash_builder, key);
+        let n = match self.ring.binary_search_by(|node| node.key.cmp(&k)) {
+            Err(n) => n,
+            Ok(n) => n,
+        };
+
+        let mut seen = HashSet::with_capacity(replicas);
+        let mut replica_nodes = Vec::with_capacity(replicas);
+
+        let len = self.ring.len();
+        for i in 0..len {
+            let idx = (n + i) % len;
+            let node = &self.ring[idx];
+
+            let key = unique_key(&node.node);
+
+            if seen.insert(key) {
+                replica_nodes.push(node.node.clone());
+
+                if replica_nodes.len() == replicas {
+                    break;
+                }
+            }
+        }
 
         Some(replica_nodes)
     }
@@ -472,6 +522,46 @@ mod tests {
             ring.get_with_replicas(&"bar", 20).unwrap(),
             vec![vnode3, vnode1, vnode2, vnode6, vnode5, vnode4],
             "too high of replicas causes the count to shrink to ring length"
+        );
+    }
+
+
+    #[test]
+    fn get_unique_replicas_skips_duplicates() {
+        let mut ring: HashRing<VNode> = HashRing::new();
+
+        assert_eq!(ring.get_with_replicas_unique_by_key(&"foo", 1, |node| node.id), None);
+
+        let vnode1 = VNode::new("127.0.0.1", 1024, 1);
+        let vnode2 = VNode::new("127.0.0.1", 1024, 2);
+        let vnode3 = VNode::new("127.0.0.2", 1024, 3);
+        let vnode4 = VNode::new("127.0.0.2", 1024, 4);
+        let vnode5 = VNode::new("127.0.0.2", 1024, 5);
+        let vnode6 = VNode::new("127.0.0.3", 1024, 6);
+
+        ring.add(vnode1);
+        ring.add(vnode2);
+        ring.add(vnode3);
+        ring.add(vnode4);
+        ring.add(vnode5);
+        ring.add(vnode6);
+
+        assert_eq!(
+            ring.get_with_replicas_unique_by_key(&"bar", 20, |vnode| vnode.addr).unwrap().len(),
+            3,
+            "replica+1 > HashRing::len() causes the count to shrink to count of unique values"
+        );
+
+        assert_eq!(
+            ring.get_with_replicas_unique_by_key(&"bar", 4, |vnode| vnode.addr).unwrap().len(),
+            3,
+            "count_of_unique_elements < replica < HashRing::len() causes the count to shrink to count of unique values"
+        );
+
+        assert_eq!(
+            ring.get_with_replicas_unique_by_key(&"bar", 4, |vnode| vnode.addr).unwrap().len(),
+            3,
+            "replica < count_of_unique_elements causes the count to match replica + 1 (primary)"
         );
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -237,11 +237,7 @@ impl<T: Hash, S: BuildHasher> HashRing<T, S> {
             return None;
         }
 
-        let replicas = if replicas > self.ring.len() {
-            self.ring.len()
-        } else {
-            replicas + 1
-        };
+        let replicas = std::cmp::min(replicas+1, self.ring.len());
 
         let k = get_key(&self.hash_builder, key);
         let n = match self.ring.binary_search_by(|node| node.key.cmp(&k)) {
@@ -252,13 +248,19 @@ impl<T: Hash, S: BuildHasher> HashRing<T, S> {
         let mut nodes = self.ring.clone();
         nodes.rotate_left(n);
 
-        // DANGER / TODO: could hang indefinitely
-        let replica_nodes = nodes
-            .iter()
-            .cycle()
-            .take(replicas)
-            .map(|node| node.node.clone())
-            .collect();
+        let mut replica_nodes = Vec::with_capacity(replicas);
+        let len = self.ring.len();
+
+        for i in 0..len {
+            let idx = (n + i) % len;
+            let node = &self.ring[idx];
+
+            replica_nodes.push(node.node.clone());
+
+            if replica_nodes.len() == replicas {
+                break;
+            }
+        }
 
         Some(replica_nodes)
     }
@@ -277,12 +279,7 @@ impl<T: Hash, S: BuildHasher> HashRing<T, S> {
             return None;
         }
 
-        let replicas = if replicas > self.ring.len() {
-            self.ring.len()
-        } else {
-            replicas + 1
-        };
-
+        let replicas = std::cmp::min(replicas + 1, self.ring.len());
         let k = get_key(&self.hash_builder, key);
         let n = match self.ring.binary_search_by(|node| node.key.cmp(&k)) {
             Err(n) => n,
@@ -495,6 +492,12 @@ mod tests {
             ring.get_with_replicas(&"foo", 4).unwrap(),
             vec![vnode5, vnode4, vnode3, vnode1, vnode2]
         );
+
+        assert_eq!(
+            ring.get_with_replicas(&"foo", 5).unwrap().len(),
+            6,
+            "return entire ring when primary + replicas == ring.len()"
+        );
     }
 
     #[test]
@@ -530,7 +533,7 @@ mod tests {
     fn get_unique_replicas_skips_duplicates() {
         let mut ring: HashRing<VNode> = HashRing::new();
 
-        assert_eq!(ring.get_with_replicas_unique_by_key(&"foo", 1, |node| node.id), None);
+        assert_eq!(ring.get_with_replicas_unique_by_key(&"foo", 1, |node| node.addr), None);
 
         let vnode1 = VNode::new("127.0.0.1", 1024, 1);
         let vnode2 = VNode::new("127.0.0.1", 1024, 2);
@@ -549,13 +552,13 @@ mod tests {
         assert_eq!(
             ring.get_with_replicas_unique_by_key(&"bar", 20, |vnode| vnode.addr).unwrap().len(),
             3,
-            "replica+1 > HashRing::len() causes the count to shrink to count of unique values"
+            "replicas+1 > HashRing::len() causes the count to shrink to count of unique values"
         );
 
         assert_eq!(
             ring.get_with_replicas_unique_by_key(&"bar", 4, |vnode| vnode.addr).unwrap().len(),
             3,
-            "count_of_unique_elements < replica < HashRing::len() causes the count to shrink to count of unique values"
+            "count_of_unique_elements < replicas+1 < HashRing::len() causes the count to shrink to count of unique values"
         );
 
         assert_eq!(


### PR DESCRIPTION
Hi,

thanks for developing this library! I recently started using it and would like to propose a few improvements:

## New feature:  `get_with_replicas_unique_by_key`
When I tried using this library I encountered the following limitation: `get_with_replicas` provides no ability to check for uniqueness criteria, i.e. an ability that following virtual nodes don't map to the same physical node.
Illustrating it with an example: when looking up 1 primary + 2 replicas in a 3+ node cluster mapped over 100 virtual nodes, there's a considerable chance the second replica will be a virtual node mapping to the same physical node as the primary.
That's why I propose introducing a new function `get_with_replicas_unique_by_key`, that allows passing a caller-specified function to compute a uniqueness criteria (usually from the fields identifying a physical node is unique, e.g. IP + port).

```rust
ring.get_with_replicas_unique_by_key(&"bar", 4, |vnode| vnode.addr).unwrap()
```

This is not possible without support directly from the library - with `get_with_replicas` you'd have to check the result, check again with an increased replica count, or call it with way too many replicas in advance to increase the chance of actually hitting a sufficient number of physically distinct physical nodes - all really unergonomic and inefficient.

## Bugfix: off by one at ring.len() boundary
```rust
let replicas = if replicas > self.ring.len() {
    self.ring.len()
} else {
    replicas + 1
};
```
breaks when replicas +1 == self.ring.len() - it will instruct the implementation to return e.g. calling the function with replicas=6 and a ring size of 6 causes it to return 7 elements.
I've replaced it with:

```rust
let replicas = std::cmp::min(replicas+1, self.ring.len());
```


## Performance improvement in `get_with_replicas`
Finally, I refactored the replica cloning function from cycles to using a modulo-indexed approach - with the `get_with_replicas_unique_by_key` the `.cycles()` call could actually hang indefinitely when there are not enough unique nodes in the ring.
However, this approach also has an advantage worth making use of in `get_with_replicas` : It avoids cloning the entire ring for every function call and only clones the nodes actually returned from the function.


## State of current tests

On my machine, the existing tests that expect specific nodes to be returned in a certain order when a specific key is looked up don't pass even on a plain clone of the repo - I don't know if it's the result of a compiler / dep version change or platform differences, but they appear to flaky to me and I would suggest changing them. That's why the tests suite doesn't pass completely with my changes.


Please let me know if you have any questions, concerns or would like to merge a subset of the changes.